### PR TITLE
Remove unknown casts from option and result enums

### DIFF
--- a/packages/option/src/index.ts
+++ b/packages/option/src/index.ts
@@ -10,8 +10,6 @@ type OptionFactories<T> = {
 	readonly none: () => undefined;
 };
 
-type AnyOptionFactories = OptionFactories<unknown>;
-
 type SomePayload<T> = EnumVariant<OptionFactories<T>, "some">;
 type NonePayload = EnumVariant<OptionFactories<unknown>, "none">;
 
@@ -29,11 +27,9 @@ type OptionMethods<T> = EnumMethods<
 	}
 >;
 
-type AnyOptionMethods = OptionMethods<unknown>;
-
-const OptionEnum = createEnum<AnyOptionFactories, AnyOptionMethods>(
+const OptionEnum = createEnum<OptionFactories<unknown>, OptionMethods<unknown>>(
 	{
-		some: (value: unknown) => ({ value }),
+		some: (value) => ({ value }),
 		none: () => undefined,
 	},
 	{
@@ -71,17 +67,16 @@ const OptionEnum = createEnum<AnyOptionFactories, AnyOptionMethods>(
 				none: () => defaultValue,
 			});
 		},
-	} as unknown as AnyOptionMethods,
+	},
 );
 
 export type Option<T> = EnumInstance<OptionFactories<T>, OptionMethods<T>>;
 export type Some<T> = Option<T> & SomePayload<T>;
 export type None = Option<never> & NonePayload;
 
-export const Some = <T>(value: T): Some<T> =>
-	OptionEnum.some(value) as unknown as Some<T>;
+export const Some = <T>(value: T): Some<T> => OptionEnum.some(value) as Some<T>;
 
-export const None = (): None => OptionEnum.none() as unknown as None;
+export const None = (): None => OptionEnum.none() as None;
 
 export const Option = Object.freeze({
 	Some,

--- a/packages/result/src/index.ts
+++ b/packages/result/src/index.ts
@@ -30,9 +30,6 @@ type ResultMethods<T, E> = EnumMethods<
 	}
 >;
 
-type AnyResultFactories = ResultFactories<unknown, unknown>;
-type AnyResultMethods = ResultMethods<unknown, unknown>;
-
 export type Result<T, E> = EnumInstance<
 	ResultFactories<T, E>,
 	ResultMethods<T, E>
@@ -40,10 +37,13 @@ export type Result<T, E> = EnumInstance<
 export type Ok<T> = Result<T, never> & OkPayload<T>;
 export type Err<E> = Result<never, E> & ErrPayload<E>;
 
-export const Result = createEnum<AnyResultFactories, AnyResultMethods>(
+export const Result = createEnum<
+	ResultFactories<unknown, unknown>,
+	ResultMethods<unknown, unknown>
+>(
 	{
-		ok: (value: unknown) => ({ value }),
-		error: (error: unknown) => ({ error }),
+		ok: (value) => ({ value }),
+		error: (error) => ({ error }),
 	},
 	{
 		isOk<T, E>(this: Result<T, E>) {
@@ -79,10 +79,9 @@ export const Result = createEnum<AnyResultFactories, AnyResultMethods>(
 				error: ({ error }: ErrPayload<E>) => Result.ok(error) as Result<E, T>,
 			});
 		},
-	} as unknown as AnyResultMethods,
+	},
 );
 
-export const Ok = <T>(value: T): Ok<T> => Result.ok(value) as unknown as Ok<T>;
+export const Ok = <T>(value: T): Ok<T> => Result.ok(value) as Ok<T>;
 
-export const Err = <E>(error: E): Err<E> =>
-	Result.error(error) as unknown as Err<E>;
+export const Err = <E>(error: E): Err<E> => Result.error(error) as Err<E>;


### PR DESCRIPTION
## Summary
- update Option enum factories and methods to avoid casting through `unknown`
- update Result enum factories and constructors to rely on direct typing rather than `unknown` casts

## Testing
- pnpm lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dba9aaef0832ca7643866cac95188)